### PR TITLE
We set parity.service 'Restart' option to 'always'

### DIFF
--- a/parity.service
+++ b/parity.service
@@ -9,7 +9,7 @@ ExecStart=/snap/bin/parity --config /etc/parity/config.toml
 # picks up users default config.toml in $HOME/.local/share/io.parity.ethereum/
 # User=username
 # Group=groupname
-Restart=on-failure
+Restart=always
 
 # Specifies which signal to use when killing a service. Defaults to SIGTERM.
 # SIGHUP gives parity time to exit cleanly before SIGKILL (default 90s)


### PR DESCRIPTION
Together with Przemek (@sikorek) we discovered that when service dies or get killed it won't restart on every occasion. But setting the Restart=always will do the trick. 

Przemek already updated all three L14 nodes to this setting. 